### PR TITLE
Fix lint command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,13 @@ npm run dev
 Then open `http://localhost:3000` in your browser.
 
 Because this environment may not allow installing packages, the project is provided without the `node_modules` directory.
+
+## Linting
+
+Run the linter with:
+
+```bash
+npm run lint
+```
+
+The script checks for `node_modules/.bin/next` and exits with an error if the dependency is missing.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "node scripts/lint.js"
   },
   "dependencies": {
     "next": "14.1.1",

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const nextBin = path.join(__dirname, '..', 'node_modules', '.bin', process.platform === 'win32' ? 'next.cmd' : 'next');
+
+if (!fs.existsSync(nextBin)) {
+  console.error('Next.js is not installed. Run "npm install" first.');
+  process.exit(1);
+}
+
+const result = spawnSync(nextBin, ['lint'], { stdio: 'inherit' });
+process.exit(result.status);


### PR DESCRIPTION
## Summary
- run linter through a helper script
- document linting in the README

## Testing
- `npm run lint` *(fails: Next.js is not installed)*