### PR TITLE
Fix extra orbit outline

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -60,8 +60,7 @@
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-  border: 1px solid rgba(255,255,255,0.2);
-  border-radius: 50%;
+  /* Remove circular border so only the SVG ellipse is visible */
   pointer-events: none;
   box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- remove the CSS border that created an extra orbit outline

## Testing
- `npm run lint` *(fails: Next.js is not installed)*